### PR TITLE
Gangplank: ensure that the local port is available for SSH

### DIFF
--- a/gangplank/internal/ocp/filer.go
+++ b/gangplank/internal/ocp/filer.go
@@ -69,14 +69,19 @@ func StartStandaloneMinioServer(ctx context.Context, srvDir, cfgFile string, ove
 	m.overSSH = overSSH
 	m.dir = srvDir
 
-	if err := m.start(ctx); err != nil {
-		return nil, err
-	}
-
-	if m.overSSH != nil {
+	// Start the minio server. If we're forwarding over SSH we'll call
+	// startMinioAndForwardOverSSH to start the minio server. because
+	// the port we use will be dynamically chosen based on the SSH
+	// connection.
+	if m.overSSH == nil {
+		if err := m.start(ctx); err != nil {
+			return nil, err
+		}
+	} else {
 		m.sshStopCh = make(chan bool, 1)
 		m.sshErrCh = make(chan error, 256)
-		if err := m.forwardOverSSH(m.sshStopCh, m.sshErrCh); err != nil {
+		err := m.startMinioAndForwardOverSSH(ctx, m.sshStopCh, m.sshErrCh)
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/gangplank/internal/ocp/ssh.go
+++ b/gangplank/internal/ocp/ssh.go
@@ -1,6 +1,7 @@
 package ocp
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -119,8 +120,8 @@ func sshClient(user, host, port string, secure bool, identity string) (*ssh.Clie
 	)
 }
 
-// forwardOverSSH forwards the minio connection over SSH.
-func (m *minioServer) forwardOverSSH(termCh termChan, errCh chan<- error) error {
+// startMinioAndForwardOverSSH starts minio and forwards the connection over SSH.
+func (m *minioServer) startMinioAndForwardOverSSH(ctx context.Context, termCh termChan, errCh chan<- error) error {
 	sshPort := 22
 	if m.overSSH.SSHPort != 0 {
 		sshPort = m.overSSH.SSHPort
@@ -132,12 +133,6 @@ func (m *minioServer) forwardOverSSH(termCh termChan, errCh chan<- error) error 
 		"remote user": m.overSSH.User,
 		"port":        sshport,
 	})
-	// Set the port to use for the proxied connection *once* here so
-	// it won't change during the course of the run. This is because
-	// below we change the m.Port to match the dynamically chosen
-	// remote port for the ssh forward but the server listening port
-	// will remain whatever the original value of m.Port is.
-	minioServerPort := m.Port
 
 	l.Info("Forwarding local port over SSH to remote host")
 
@@ -164,8 +159,17 @@ func (m *minioServer) forwardOverSSH(termCh termChan, errCh chan<- error) error 
 	// Update m.Port in the minioServer definition so the miniocfg
 	// that gets passed to the remote specifies the correct port for
 	// the local connection there.
-	log.Infof("Changing remote local port (forward) from %v to %v", m.Port, remoteSSHport)
+	log.Infof("Changing minio port for local and remote (forward) from %v to %v",
+		m.Port, remoteSSHport)
 	m.Port = remoteSSHport
+
+	// Now that we know the port let's start the minio server. It's
+	// highly unlikely to have a port conflict here because we are
+	// running inside the cosa container where no other services are
+	// running/listening.
+	if err := m.start(ctx); err != nil {
+		return err
+	}
 
 	// copyIO is a blind copier that copies between source and destination
 	copyIO := func(src, dest net.Conn) {
@@ -176,7 +180,7 @@ func (m *minioServer) forwardOverSSH(termCh termChan, errCh chan<- error) error 
 
 	// proxy is a helper function that connects the local port to the remoteClient
 	proxy := func(conn net.Conn) {
-		proxy, err := net.Dial("tcp4", fmt.Sprintf("127.0.0.1:%d", minioServerPort))
+		proxy, err := net.Dial("tcp4", fmt.Sprintf("127.0.0.1:%d", m.Port))
 		if err != nil {
 			err = fmt.Errorf("%w: failed to open local port for proxy", err)
 			errCh <- err


### PR DESCRIPTION
This builds on PR #2378 which maps the remote port to the local port.
However, if the local port is in use, then Gangplank will fail to
launch.